### PR TITLE
add BufWritePre for *.tf files and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
 # vim-hclfmt
 
-Vim plugin to format hcl files. It support auto format on save. Under the hood
-it uses [hclfmt](https://github.com/fatih/hclfmt)
+Vim plugin to format Hashicorp Configuration Language (HCL) files, this
+format is used by a number of Hashicorp tools, such as Terraform as the
+language used for configuration.
+
+The plugin by default will format *.hcl and *.tf files on save. Under the
+hood it uses [hclfmt](https://github.com/fatih/hclfmt) to process the files.
 
 ![hclfmt](http://g.recordit.co/fIQfohsGPI.gif)
 
@@ -9,10 +13,12 @@ it uses [hclfmt](https://github.com/fatih/hclfmt)
 
 Save the file or call `:HclFmt`. 
 
-By default vim-hclfmt automatically formats the file. To disable it:
+By default vim-hclfmt automatically formats *.hcl and *.tf files. These
+can be disabled by filetype as follows:
 
 ```
 g:hcl_fmt_autosave = 0
+g:tf_fmt_autosave = 0
 ```
 
 ## Install
@@ -29,5 +35,3 @@ plugin's install command.
   * `NeoBundle 'fatih/vim-hclfmt'`
 *  [Vundle](https://github.com/gmarik/vundle)
   * `Plugin 'fatih/vim-hclfmt'`
-
-

--- a/plugin/hcl.vim
+++ b/plugin/hcl.vim
@@ -2,6 +2,10 @@ if get(g:, "hcl_fmt_autosave", 1)
     autocmd BufWritePre *.hcl call fmt#Format()
 endif
 
+if get(g:, "tf_fmt_autosave", 1)
+    autocmd BufWritePre *.tf call fmt#Format()
+endif
+
 command! -nargs=0 HclFmt call fmt#Format()
 
 


### PR DESCRIPTION
First up thanks for writing hclfmt and this plugin! 

This is a tiny patch to also format `*.tf` files pre-save. I made it configurable independently from `*.hcl`, not sure if there is a case where folks may want to format only one specific type so let me know if you'd rather just have both types covered by a single configuration switch and I can remove the additional config var.
