### PR TITLE
Add hclfmt install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,7 @@ plugin's install command.
   * `NeoBundle 'fatih/vim-hclfmt'`
 *  [Vundle](https://github.com/gmarik/vundle)
   * `Plugin 'fatih/vim-hclfmt'`
+
+If [hclfmt](https://github.com/fatih/hclfmt) is not already installed:
+
+    go get github.com/fatih/hclfmt


### PR DESCRIPTION
Add dependency installation instructions.

I forgot to install hclfmt on first attempt, maybe it would be better to include in README.md.